### PR TITLE
fix: 새로고침 시 로그인 상태 유실 문제 해결

### DIFF
--- a/backend/src/main/java/com/example/backend/dto/AccessTokenAndProfileResponseDTO.java
+++ b/backend/src/main/java/com/example/backend/dto/AccessTokenAndProfileResponseDTO.java
@@ -1,0 +1,17 @@
+package com.example.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccessTokenAndProfileResponseDTO {
+    private String accessToken;
+    private Long id;
+    private String name;
+    private String email;
+}

--- a/backend/src/main/java/com/example/backend/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.backend.service;
 
+import com.example.backend.dto.AccessTokenAndProfileResponseDTO;
 import com.example.backend.dto.JwtAndProfileResponseDTO;
 import com.example.backend.entity.User;
 import com.example.backend.repository.UserRepository;
@@ -88,8 +89,19 @@ public class UserService implements UserDetailsService {
                 .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
     }
 
-    public User getUserByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+    /**
+     * 유효한 토큰에서 받은 사용자 ID(String)로 프로필 정보와 새로운 토큰을 함께 조회합니다.
+     * @param userIdFromToken 유효한 토큰에서 추출한 사용자 ID (String)
+     * @return 프로필 정보와 새로운 토큰이 담긴 AccessTokenAndProfileResponseDTO
+     */
+    public AccessTokenAndProfileResponseDTO getProfileWithNewToken(String userIdFromToken) {
+        try {
+            Long userId = Long.parseLong(userIdFromToken);
+            User user = getUserByUserId(userId);
+            String newAccessToken = jwtUtil.generateAccessToken(user.getId());
+            return new AccessTokenAndProfileResponseDTO(newAccessToken, user.getId(), user.getEmail(), user.getName());
+        } catch (NumberFormatException e) {
+            throw new RuntimeException("Invalid user ID format in token: " + userIdFromToken);
+        }
     }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -6,6 +6,7 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import axios from 'axios'
+import { useAuthStore } from "@/stores/auth.js";
 
 axios.defaults.withCredentials = true; // 모든 요청에서 쿠키 자동 포함
 
@@ -14,5 +15,11 @@ const app = createApp(App)
 
 app.use(pinia)
 app.use(router)
+
+// 애플리케이션 마운트 후, router.isReady를 기다린 다음 restoreAuth 호출
+router.isReady().then(() => {
+    const authStore = useAuthStore();
+    authStore.restoreAuth();
+});
 
 app.mount('#app')

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -22,6 +22,21 @@ const router = createRouter({
 // 전역 네비게이션 가드
 router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore();
+
+  // ★ 로그인 상태 복원 로직 추가
+  // 페이지 새로고침 시 Pinia 스토어가 초기화되므로,
+  // localStorage의 토큰을 사용하여 로그인 상태를 먼저 복원합니다.
+  if (!authStore.accessToken && localStorage.getItem('accessToken')) {
+    try {
+      await authStore.restoreAuth();
+    } catch (e) {
+      // 토큰이 유효하지 않으면 로그인 페이지로 리다이렉트
+      console.error("Failed to restore auth state, redirecting to login.");
+      authStore.clearLoginInfo();
+      return next('/login');
+    }
+  }
+
   const isLoggedIn = !!authStore.accessToken;
 
   // 인증이 필요한 페이지에 접근했고, 로그인 상태가 아닌 경우

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import axios from "@/utils/axios.js";
 
 export const useAuthStore = defineStore('auth', () => {
     // 상태 (State)
@@ -10,13 +11,45 @@ export const useAuthStore = defineStore('auth', () => {
     const setLoginInfo = (token, userData) => {
         accessToken.value = token;
         user.value = userData;
+        localStorage.setItem('accessToken', token); // localStorage에도 저장
     };
 
     const clearLoginInfo = () => {
         accessToken.value = null;
         user.value = null;
+        localStorage.removeItem('accessToken'); // localStorage에서도 삭제
+    };
+
+    const restoreAuth = async () => {
+        const storedToken = localStorage.getItem('accessToken');
+        if (storedToken) {
+            try {
+                console.log("Restoring auth state...");
+                // 토큰을 스토어에 임시로 설정하여 요청 인터셉터가 헤더에 담을 수 있도록 합니다.
+                accessToken.value = storedToken;
+
+                // 백엔드에 토큰 유효성 검사 및 프로필 정보 요청
+                // axios.js의 인터셉터가 이 요청의 Authorization 헤더에 storedToken을 자동으로 추가합니다.
+                const response = await axios.get('/auth/profile');
+
+                // ★ 응답으로 받은 새로운 accessToken과 사용자 정보를 추출
+                const { accessToken: newAccessToken, ...userData } = response.data;
+
+                // ★ 새로운 accessToken을 스토어와 localStorage에 저장하여 세션을 갱신합니다.
+                accessToken.value = newAccessToken;
+                localStorage.setItem('accessToken', newAccessToken);
+
+                // 프로필 정보만 스토어에 저장
+                user.value = userData;
+                console.log("Auth state restored.");
+            } catch (error) {
+                console.error("Failed to restore auth state:", error);
+                // 토큰이 유효하지 않으면 로그인 정보 초기화
+                clearLoginInfo();
+            }
+        }
     };
 
     // 상태와 액션을 반환
-    return { accessToken, user, setLoginInfo, clearLoginInfo };
+    return { accessToken, user, setLoginInfo, clearLoginInfo, restoreAuth };
 });

--- a/frontend/src/views/OAuth2RedirectHandler.vue
+++ b/frontend/src/views/OAuth2RedirectHandler.vue
@@ -9,22 +9,21 @@ const router = useRouter();
 const authStore = useAuthStore(); // 스토어 인스턴스 사용
 
 onMounted(async () => {
-  console.log('OAuth2RedirectHandler onMounted');
 
   const code = route.query.code;
 
   if (code) {
-    console.log('if code');
     try {
-      console.log('try');
       // 1. 백엔드 API 호출 (code를 쿼리 파라미터로 전달)
       const response = await axios.post(`/auth/google/login`, { code: code });
 
-      console.log('response: ', response);
-
       // 2. 응답 데이터에서 토큰과 프로필 정보 추출
       const { accessToken, id, name, email } = response.data; // 순서 상관 X
+
       console.log("로그인 성공! 응답 데이터:", response.data);
+
+      // localStorage에 accessToken 추가
+      // localStorage.setItem("accessToken", accessToken);
 
       // 3. Pinia 스토어에 로그인 정보 저장
       // setLoginInfo는 액세스 토큰과 사용자 데이터를 받습니다.


### PR DESCRIPTION
## 요약

SPA(Single Page Application) 환경에서 발생하는 '새로고침 시 로그인 상태 유실' 문제를 해결하고, 사용자 경험을 개선하는 기능을 구현했습니다. Vue Router의 네비게이션 가드에 `localStorage` 기반의 로그인 상태 복원 로직을 추가하고, 백엔드에서 새로운 토큰을 롤링하는 기능을 도입하여 인증 시스템의 안정성을 높였습니다.

## 주요 변경 사항

* **프론트엔드 (`index.js`, `auth.js`)**
    * `router/index.js`의 네비게이션 가드에 `localStorage` 기반의 로그인 상태 복원 로직을 추가했습니다. `localStorage`에 토큰이 있을 경우, Pinia 스토어의 `authStore.restoreAuth()`를 호출하여 로그인 상태를 복원합니다.
    * `auth.js`의 `restoreAuth` 액션은 백엔드로부터 받은 새로운 `accessToken`과 사용자 정보를 스토어에 저장하여 토큰을 갱신합니다.
* **백엔드 (`AuthController.java`, `UserService.java`)**
    * **`/api/auth/profile` API**를 추가했습니다. 이 API는 유효한 토큰을 가진 사용자의 요청을 받으면, 해당 사용자의 프로필 정보와 함께 **새로 생성된 액세스 토큰**을 반환합니다.
    * `UserService.java`에 `getProfileWithNewToken` 메서드를 추가하여, 사용자 ID를 기반으로 프로필 정보를 조회하고 `JwtUtil`을 사용해 새로운 토큰을 생성하는 로직을 통합했습니다.

## 구현 목표

* **SPA 환경의 로그인 상태 유지**
    * 새로고침 시 Vue 애플리케이션의 상태가 초기화되어 발생하는 로그인 상태 유실 문제를 해결합니다. `localStorage`에 저장된 토큰을 사용하여 로그인 상태를 복원함으로써, 사용자에게 끊김 없는 경험을 제공하는 것이 주요 목표입니다.
* **불필요한 리디렉션 방지**
    * 로그인한 사용자가 새로고침 후에도 로그인 페이지로 불필요하게 리디렉션되는 문제를 해결합니다.
* **토큰 롤링(Token Rolling) 패턴 도입**
    * `/profile` API 호출 시 기존 토큰을 갱신하여 반환함으로써, 토큰의 유효성을 연장하고 보안성을 강화했습니다.

## 테스트 방법

1.  **로그인 수행**: 애플리케이션에 정상적으로 로그인합니다.
2.  **페이지 이동**: 로그인 후 `/profile`과 같이 인증이 필요한 페이지로 이동합니다.
3.  **새로고침**: `/profile` 페이지에서 브라우저를 새로고침(F5)합니다.
4.  **결과 확인**: 새로고침 후에도 로그인 상태가 유지되고 `/profile` 페이지에 정상적으로 머무르는지 확인합니다. 만약 유효하지 않은 토큰으로 테스트한다면 로그인 페이지로 리디렉션되어야 합니다.