### PR TITLE
fix: 로그인 시 refreshToken을 DTO에 포함시켜 HttpOnly 쿠키에 정상 저장

### DIFF
--- a/backend/src/main/java/com/example/backend/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/service/UserService.java
@@ -61,7 +61,7 @@ public class UserService implements UserDetailsService {
         // 이 DTO는 AuthController에서 사용됩니다.
 
         // 쿠키를 통해 컨트롤러에서 브라우저에 전달
-        return new JwtAndProfileResponseDTO(accessToken, null, user.getId(), user.getEmail(), user.getName());
+        return new JwtAndProfileResponseDTO(accessToken, refreshToken, user.getId(), user.getEmail(), user.getName());
     }
 
     @Override

--- a/backend/src/main/java/com/example/backend/util/CookieUtil.java
+++ b/backend/src/main/java/com/example/backend/util/CookieUtil.java
@@ -1,5 +1,7 @@
 package com.example.backend.util;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
@@ -43,5 +45,27 @@ public class CookieUtil {
     public void expireCookie(HttpServletResponse response, String name) {
         // 쿠키 값을 비우고, maxAge를 0으로 설정하여 즉시 만료시킵니다.
         addJwtCookie(response, name, "", 0);
+    }
+
+    /**
+     * HttpServletRequest에서 특정 이름의 쿠키 값을 가져옵니다.
+     * @param request HttpServletRequest
+     * @param name 찾을 쿠키 이름
+     * @return 쿠키 값, 없으면 null
+     */
+    public String getCookieValue(HttpServletRequest request, String name) {
+
+        System.out.println("getCookieValue, request: " + request);
+
+        if (request.getCookies() == null) {
+            return null;
+        }
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                System.out.println("getCookieValue, cookie: " + cookie);
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 }

--- a/frontend/src/views/OAuth2RedirectHandler.vue
+++ b/frontend/src/views/OAuth2RedirectHandler.vue
@@ -22,9 +22,6 @@ onMounted(async () => {
 
       console.log("로그인 성공! 응답 데이터:", response.data);
 
-      // localStorage에 accessToken 추가
-      // localStorage.setItem("accessToken", accessToken);
-
       // 3. Pinia 스토어에 로그인 정보 저장
       // setLoginInfo는 액세스 토큰과 사용자 데이터를 받습니다.
       authStore.setLoginInfo(accessToken, { id, name, email });

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -11,12 +11,12 @@ const { user } = storeToRefs(authStore); // 스토어에서 user 정보 가져�
 const logout = async () => {
   try {
     // 1. 백엔드 로그아웃 API 호출
-    await axios.post('/api/auth/logout');
+    await axios.post('/auth/logout');
 
     // 2. Pinia 스토어에서 정보 제거
     authStore.clearLoginInfo();
 
-    alert('로그아웃 완료');
+    console.log('로그아웃 완료');
 
     // 3. 로그인 페이지로 리다이렉트
     router.push('/login');
@@ -32,8 +32,15 @@ const logout = async () => {
   <div class="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
     <div class="bg-white p-8 rounded-xl shadow-lg text-center">
       <h2 class="text-2xl font-bold mb-4 text-gray-800">프로필</h2>
-      <p class="text-gray-700 text-lg mb-2"><strong>이름:</strong> {{ user.name }}</p>
-      <p class="text-gray-700 text-lg"><strong>이메일:</strong> {{ user.email }}</p>
+      <!-- user 객체가 null이 아닐 때만 내용을 표시 -->
+      <div v-if="user">
+        <p class="text-gray-700 text-lg mb-2"><strong>이름:</strong> {{ user.name }}</p>
+        <p class="text-gray-700 text-lg"><strong>이메일:</strong> {{ user.email }}</p>
+      </div>
+      <div v-else>
+        <!-- 로딩 상태 또는 로그인 정보가 없을 때 메시지를 표시 -->
+        <p class="text-gray-600">로딩 중이거나 로그인 정보가 없습니다.</p>
+      </div>
       <button
           @click="logout"
           class="mt-6 w-full py-2 px-4 bg-red-500 text-white font-semibold rounded-lg shadow-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-opacity-75 transition duration-300"


### PR DESCRIPTION
## 변경 사항
- UserService에서 반환하는 DTO에 refreshToken을 포함하도록 수정
- AuthController에서 DTO의 refreshToken을 HttpOnly 쿠키에 세팅
- 로그인 후 클라이언트가 refreshToken을 받아 로그아웃 가능하도록 개선
- CookieUtil에서 요청에서 특정 이름을 가진 쿠키 값 가져오는 기능 추가
- 브라우저의 refreshToken 쿠키 만료 기능 추가

## 배경
기존에는 로그인 시에는 DTO에 refreshToken이 null로 세팅되어 쿠키가 비어있었음.
로그아웃 시 POST 요청인데 매개변수가 request가 아닌 refreshtoken으로 되어있었음.
이로 인해 로그아웃 기능이 정상 동작하지 않았음.

## 결과
- 로그인 후 refreshToken이 정상적으로 쿠키에 저장됨
- 클라이언트에서 로그아웃 시 토큰 삭제 및 쿠키 만료 처리 정상 동작
