### PR TITLE
chore: 주석 처리된 불필요 RT 재발급 로직 제거

### DIFF
--- a/backend/src/main/java/com/example/backend/service/AuthService.java
+++ b/backend/src/main/java/com/example/backend/service/AuthService.java
@@ -72,24 +72,6 @@ public class AuthService {
 
         System.out.println("newAccessToken: " + newAccessToken);
 
-        // 6. Refresh Token 만료 임박 시 새 Refresh Token 발급
-//        if (isRefreshTokenExpiresSoon(user)) {
-//            System.out.println("리프레시 토큰 만료 임박");
-//
-//            String newRefreshToken = jwtUtil.generateRefreshToken(user.getId());
-//            user.setRefreshToken(newRefreshToken);
-////            user.setRefreshTokenExpiry(LocalDateTime.now().plusSeconds(10)); // 리프레시토큰 기간 10초
-////            user.setRefreshTokenExpiry(LocalDateTime.now().plusDays(7)); // 리프레시토큰 기간 7일
-//            user.setRefreshTokenExpiry(LocalDateTime.now().plusSeconds(refreshTokenValidityInSeconds)); // 리프레시토큰 기간 1일 20초 (초)
-//            userRepository.save(user);
-//
-//            // 쿠키에 새 Refresh Token 설정
-////            cookieUtil.addJwtCookie(response, "refreshToken", refreshToken, 60 * 60 * 24 * 7); // 7일 (s)
-////            cookieUtil.addJwtCookie(response, "refreshToken", refreshToken, 10); // 10초 (s)
-////            cookieUtil.addJwtCookie(response, "refreshToken", refreshToken, 60 * 60 * 24 + 20); // 1일 20초 (s)
-//            cookieUtil.addJwtCookie(response, "refreshToken", refreshToken, refreshTokenValidityInSeconds); // 1일 20초 (s)
-//        }
-
         return newAccessToken;
     }
 
@@ -108,10 +90,4 @@ public class AuthService {
         }
         return refreshToken;
     }
-
-    // 8. Refresh Token 만료 임박 체크 (예: 남은 기간 1일 이하)
-//    private boolean isRefreshTokenExpiresSoon(User user) {
-//        System.out.println("isRefreshTokenExpiresSoon 메소드 진입 - 토큰 만료 임박 체크");
-//        return ChronoUnit.DAYS.between(LocalDateTime.now(), user.getRefreshTokenExpiry()) <= 1;
-//    }
 }


### PR DESCRIPTION
## 🧹 작업 내용 (Chore)

현재 서비스 핵심 기능 개발에 집중하고 코드베이스를 안정화하기 위해, **작동하지 않고 주석 처리되어 있던 RT 재발급 (Rotation) 관련 로직을 완전히 제거**했습니다.

* AuthService 내의 RT 재발급 관련 if 블록 및 isRefreshTokenExpiresSoon 함수 정의를 삭제했습니다.
* 미완성 코드를 제거하여 코드베이스의 안정성과 가독성을 높였습니다.

## ✅ 영향 범위

* **영향 없음:** 핵심 인증 로직 (로그인, 로그아웃, AT 자동 갱신, RT 만료 시 강제 로그아웃)은 이미 안정적으로 작동하며, 이번 작업으로 기능적 영향은 없습니다.
* **향상:** 코드가 깔끔해져 이후 유지보수가 용이해집니다.