### PR TITLE
feat: 초기 기술 목표 달성 후, 프로덕트의 가치를 높이기 위한 루티노트 컨셉 및 UI/UX 적용

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <title>루티노트: 오늘의 작은 성공 기록</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/components/ConfirmationModal.vue
+++ b/frontend/src/components/ConfirmationModal.vue
@@ -83,13 +83,13 @@ onUnmounted(() => {
       @click.self="close"
   >
     <!-- 모달 컨테이너 -->
-    <div class="bg-white p-8 rounded-xl shadow-2xl w-full max-w-sm transform transition-all duration-300 scale-100 opacity-100">
+    <div class="bg-white p-6 rounded-xl shadow-2xl w-full max-w-md transform transition-all duration-300 scale-100 opacity-100">
 
       <!-- 제목 -->
       <h2 class="text-xl font-bold mb-4 text-gray-900">{{ title }}</h2>
 
       <!-- 메시지 -->
-      <p class="mb-6 text-gray-700">{{ message }}</p>
+      <p class="mb-6 text-gray-700 break-words">{{ message }}</p>
 
       <!-- 에러 메시지 -->
       <p v-if="error" class="text-red-500 text-sm mb-4 font-medium bg-red-50 p-2 rounded border border-red-200">

--- a/frontend/src/components/ConfirmationModal.vue
+++ b/frontend/src/components/ConfirmationModal.vue
@@ -79,7 +79,7 @@ onUnmounted(() => {
   <!-- 모달 오버레이 -->
   <div
       v-if="show"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-opacity"
+      class="fixed inset-0 backdrop-brightness-40 flex items-center justify-center z-50 transition-opacity"
       @click.self="close"
   >
     <!-- 모달 컨테이너 -->

--- a/frontend/src/components/ConfirmationModal.vue
+++ b/frontend/src/components/ConfirmationModal.vue
@@ -24,11 +24,11 @@ const props = defineProps({
   },
   confirmButtonText: {
     type: String,
-    default: '확인',
+    default: '확인하기',
   },
   cancelButtonText: {
     type: String,
-    default: '취소',
+    default: '취소하기',
   },
   confirmButtonClass: {
     type: String,
@@ -89,7 +89,7 @@ onUnmounted(() => {
       <h2 class="text-xl font-bold mb-4 text-gray-900">{{ title }}</h2>
 
       <!-- 메시지 -->
-      <p class="mb-6 text-gray-700 break-words">{{ message }}</p>
+      <p class="mb-6 text-gray-700 whitespace-pre-wrap break-normal">{{ message }}</p>
 
       <!-- 에러 메시지 -->
       <p v-if="error" class="text-red-500 text-sm mb-4 font-medium bg-red-50 p-2 rounded border border-red-200">
@@ -97,7 +97,7 @@ onUnmounted(() => {
       </p>
 
       <!-- 액션 버튼 -->
-      <div class="flex justify-center space-x-4">
+      <div class="flex justify-end space-x-4">
         <!-- 취소 버튼 -->
         <button
             v-if="cancelButtonText && cancelButtonText.trim() !== ''" @click="close"

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -73,7 +73,7 @@ const logout = async () => {
             isActivePath('/') ? activeClasses : inactiveClasses
         ]"
     >
-      Home
+      메인
     </RouterLink>
     <RouterLink
         to="/board"
@@ -82,7 +82,7 @@ const logout = async () => {
             isBoardActive() ? activeClasses : inactiveClasses
         ]"
     >
-      게시판
+      루틴 피드
     </RouterLink>
 
     <!-- 로그인 시에만 Profile 링크 표시 -->
@@ -94,7 +94,7 @@ const logout = async () => {
             isActivePath('/profile') ? activeClasses : inactiveClasses
         ]"
     >
-      Profile
+      나의 노트
     </RouterLink>
 
     <!-- 로그인 상태에 따른 조건부 렌더링: Login 링크 -->
@@ -113,7 +113,7 @@ const logout = async () => {
     <!-- ⭐️ [수정] ml-6 대신 justify-end를 사용하여 오른쪽 정렬을 유지하고, flex-shrink-0을 추가하여 이 영역이 좁아지지 않게 함 ⭐️ -->
     <div
         v-if="isLoggedIn"
-        class="ml-auto text-gray-600 font-medium text-sm flex items-center space-x-3 flex-shrink-0">
+        class="ml-auto pl-5 text-gray-600 font-medium text-sm flex items-center space-x-3 flex-shrink-0">
       <!-- ⭐️ [수정] 사용자 이름 텍스트도 강제 줄바꿈 방지 ⭐️ -->
       <p class="whitespace-nowrap">
         {{user.name}} 님

--- a/frontend/src/components/comment/CommentForm.vue
+++ b/frontend/src/components/comment/CommentForm.vue
@@ -54,12 +54,11 @@ const emit = defineEmits('comment-submitted');
 </script>
 
 <template>
-  <div class="mb-8">
-    <h3 class="text-lg font-semibold mb-3 mt-6 text-gray-700">댓글 작성</h3>
+  <div class="mb-6 mt-6">
 
     <!-- 비로그인 상태 안내 -->
-    <div v-if="!isAuthenticated" class="p-4 bg-gray-100 border border-gray-300 rounded-lg text-center text-gray-600">
-      댓글을 작성하려면 로그인해주세요.
+    <div v-if="!isAuthenticated" class="p-4 mt-6 bg-gray-100 border border-gray-300 rounded-lg text-center text-gray-600">
+      응원/질문을 작성하려면 로그인해주세요.
     </div>
 
     <!-- 로그인 상태 - 댓글 폼 -->
@@ -67,7 +66,7 @@ const emit = defineEmits('comment-submitted');
         <textarea
             v-model="newCommentContent"
             rows="4"
-            :placeholder="`댓글을 입력하세요. (${authorName}님으로 작성)`"
+            :placeholder="`궁금한 점을 질문하거나, 응원의 메시지를 남겨보세요!`"
             class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 transition duration-150 resize-none text-gray-800"
             :disabled="commentStore.isLoading"
         ></textarea>
@@ -80,7 +79,7 @@ const emit = defineEmits('comment-submitted');
             :disabled="!isFormValid || commentStore.isLoading"
             class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-5 rounded-lg transition duration-200 shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {{ commentStore.isLoading ? '등록 중...' : '댓글 등록' }}
+          {{ commentStore.isLoading ? '등록 중...' : '등록하기' }}
         </button>
       </div>
     </div>

--- a/frontend/src/components/comment/CommentForm.vue
+++ b/frontend/src/components/comment/CommentForm.vue
@@ -18,11 +18,11 @@ const isFormValid = computed(() => newCommentContent.value.trim().length > 0);
 
 const handleSubmitComment = async () => {
   if (!isAuthenticated.value) {
-    commentError.value = '로그인 후 댓글을 작성할 수 있습니다.';
+    commentError.value = '로그인 후 응원/질문을 작성할 수 있습니다.';
     return;
   }
   if (!isFormValid.value) {
-    commentError.value = '댓글 내용을 입력해주세요.';
+    commentError.value = '응원/질문 내용을 입력해주세요.';
     return;
   }
 
@@ -37,10 +37,10 @@ const handleSubmitComment = async () => {
     newCommentContent.value = '';
 
     // 댓글 작성 성공 토스트 메시지를 부모에게 전달합니다. (BoardDetail.vue에서 수신)
-    emit('comment-submitted', '댓글이 성공적으로 작성되었습니다.', 'success');
+    emit('comment-submitted', '응원/질문이 성공적으로 작성되었습니다.', 'success');
   } catch (err) {
     // Store에서 발생한 오류 메시지 사용
-    commentError.value = commentStore.error || '댓글 작성 중 알 수 없는 오류가 발생했습니다.';
+    commentError.value = commentStore.error || '응원/질문 작성 중 알 수 없는 오류가 발생했습니다.';
     console.error('댓글 작성 오류: ', err);
 
     // 실패 토스트 메시지를 부모에게 전달합니다.
@@ -77,7 +77,7 @@ const emit = defineEmits('comment-submitted');
         <button
             @click="handleSubmitComment"
             :disabled="!isFormValid || commentStore.isLoading"
-            class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-5 rounded-lg transition duration-200 shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+            class="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold py-2 px-5 rounded-lg transition duration-200 shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ commentStore.isLoading ? '등록 중...' : '등록하기' }}
         </button>

--- a/frontend/src/components/comment/CommentItem.vue
+++ b/frontend/src/components/comment/CommentItem.vue
@@ -57,7 +57,7 @@ const saveEdit = async () => {
 
   // 2. 유효성 검사 (빈 내용 방지)
   if (editContent.value.trim().length === 0) {
-    editError.value = '댓글 내용을 입력해주세요.';
+    editError.value = '응원/질문 내용을 입력해주세요.';
     return;
   }
 
@@ -67,10 +67,10 @@ const saveEdit = async () => {
     editError.value = null;
 
     // 부모에게 성공 알림을 보냅니다. (BoardDetail의 Toast를 사용하기 위함)
-    emit('comment-submitted', '댓글이 성공적으로 수정되었습니다.', 'success');
+    emit('comment-submitted', '응원/질문이 성공적으로 수정되었습니다.', 'success');
   } catch (err) {
     // Store에서 발생한 오류 메시지 사용
-    editError.value = commentStore.error || '댓글 수정에 실패했습니다.';
+    editError.value = commentStore.error || '응원/질문 수정에 실패했습니다.';
     console.error('댓글 수정 오류:', err);
 
     // 실패 토스트 메시지를 부모에게 전달
@@ -99,17 +99,17 @@ const openDeleteModal = () => {
       <div v-if="isCommentAuthor && !isEditing" class="flex space-x-1">
         <button
             @click="startEdit"
-            class="text-blue-500 hover:text-blue-700 text-xs font-medium transition duration-150 px-2 py-1 rounded-full"
-            title="댓글 수정"
+            class="text-emerald-500 hover:text-emerald-600 text-xs font-medium transition duration-150 px-2 py-1 rounded-full"
+            title="응원/질문 수정"
         >
-          수정
+          수정하기
         </button>
         <button
             @click="openDeleteModal"
-            class="text-red-500 hover:text-red-700 text-xs font-medium transition duration-150 px-2 py-1 rounded-full"
-            title="댓글 삭제"
+            class="text-red-500 hover:text-red-600 text-xs font-medium transition duration-150 px-2 py-1 rounded-full"
+            title="응원/질문 삭제"
         >
-          삭제
+          삭제하기
         </button>
       </div>
     </div>
@@ -124,7 +124,7 @@ const openDeleteModal = () => {
         <textarea
             v-model="editContent"
             rows="3"
-            class="w-full px-3 py-2 border border-blue-400 rounded-lg focus:ring-2 focus:ring-blue-500 transition duration-150 resize-none text-gray-800"
+            class="w-full px-3 py-2 border border-gray-400 rounded-lg focus:ring-2 focus:ring-blue-500 transition duration-150 resize-none text-gray-800"
             :disabled="commentStore.isLoading"
         ></textarea>
 
@@ -133,17 +133,17 @@ const openDeleteModal = () => {
       <div class="flex justify-end space-x-2">
         <button
             @click="cancelEdit"
-            class="bg-gray-400 hover:bg-gray-500 text-white text-sm py-1 px-3 rounded-lg transition duration-200"
+            class="bg-gray-200 hover:bg-gray-300 text-gray-700 text-sm py-1 px-3 rounded-lg transition duration-200"
             :disabled="commentStore.isLoading"
         >
-          취소
+          취소하기
         </button>
         <button
             @click="saveEdit"
             :disabled="commentStore.isLoading || editContent.trim().length === 0"
-            class="bg-blue-600 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded-lg transition duration-200 disabled:opacity-50"
+            class="bg-emerald-500 hover:bg-emerald-600 text-white text-sm py-1 px-3 rounded-lg transition duration-200 disabled:opacity-50"
         >
-          저장
+          수정하기
         </button>
       </div>
     </div>

--- a/frontend/src/components/comment/CommentList.vue
+++ b/frontend/src/components/comment/CommentList.vue
@@ -37,14 +37,17 @@ const handleCommentSubmitted = (message, type) => {
 <template>
   <div>
     <!-- 댓글 개수를 표시하는 제목 -->
-    <h2 class="text-2xl font-bold mb-6 mt-8 text-gray-800 border-b pb-3">
-      댓글 ({{ commentStore.commentCount }})
+    <h2 class="text-2xl font-bold mb-6 text-gray-800 border-b pb-3">
+      응원과 질문 ({{ commentStore.commentCount }})
     </h2>
+
+    <!-- ⭐️ 댓글 작성 폼 배치 (목록 위에 위치) ⭐️ -->
+    <CommentForm @comment-submitted="handleCommentSubmitted" />
 
     <!-- 로딩 상태 -->
     <div v-if="commentStore.isLoading && commentStore.commentCount === 0" class="text-center py-5">
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-      <p class="mt-2 text-gray-600">댓글을 불러오는 중...</p>
+      <p class="mt-2 text-gray-600">응원과 질문을 불러오는 중...</p>
     </div>
 
     <!-- 에러 상태 -->
@@ -54,7 +57,7 @@ const handleCommentSubmitted = (message, type) => {
 
     <!-- 빈 목록 상태 -->
     <div v-else-if="commentStore.commentCount === 0" class="text-center py-5 text-gray-500">
-      등록된 댓글이 없습니다. 첫 댓글을 작성해보세요!
+      아직 소통이 없어요. 첫 질문이나 응원의 메시지를 남겨보세요!
     </div>
 
     <!-- 댓글 목록 -->
@@ -67,8 +70,5 @@ const handleCommentSubmitted = (message, type) => {
           @comment-submitted="handleCommentSubmitted"
       />
     </div>
-
-    <!-- ⭐️ 댓글 작성 폼 배치 (목록 위에 위치) ⭐️ -->
-    <CommentForm @comment-submitted="handleCommentSubmitted" />
   </div>
 </template>

--- a/frontend/src/components/top/TopPostList.vue
+++ b/frontend/src/components/top/TopPostList.vue
@@ -41,7 +41,7 @@ const goToBoard = () => {
     </div>
 
     <div v-if="isLoading" class="text-center text-gray-500 py-10">
-      게시글을 불러오는 중입니다...
+      베스트 갓생 Top4를 불러오는 중입니다...
     </div>
 
     <div v-else-if="topPosts.length"
@@ -55,7 +55,7 @@ const goToBoard = () => {
     </div>
 
     <div v-else class="text-center text-gray-500 py-10 border-2 border-dashed border-gray-300 rounded-lg">
-      아직 인기 게시글이 없습니다.
+      아직 베스트 갓생 Top4가 없습니다.
     </div>
   </div>
 </template>

--- a/frontend/src/views/BoardDetailView.vue
+++ b/frontend/src/views/BoardDetailView.vue
@@ -129,7 +129,7 @@ const confirmDeletePost = async () => {
 
     // 2. ⭐️ [핵심] 토스트 메시지 상태를 Pinia Store에 저장하고 이동합니다. ⭐️
     // BoardList.vue에서 이 상태를 확인하고 토스트를 띄웁니다.
-    boardStore.setTransientToast('게시글이 성공적으로 삭제되었습니다.', 'success');
+    boardStore.setTransientToast('루틴이 성공적으로 삭제되었습니다.', 'success');
 
     // 3. 목록으로 이동
     router.push({name: 'BoardList'});
@@ -138,10 +138,10 @@ const confirmDeletePost = async () => {
 
   } catch (error) {
     // 3. 삭제 실패: 에러 메시지를 모달에 표시
-    const errorMessage = error.response?.data?.message || "게시글 삭제에 실패했습니다. 권한을 확인해 주세요.";
+    const errorMessage = error.response?.data?.message || "루틴 삭제에 실패했습니다. 권한을 확인해 주세요.";
     postDeleteError.value = errorMessage;
 
-    console.error("삭제 실패:", error);
+    console.error("게시글 삭제 실패:", error);
   }
 };
 
@@ -163,11 +163,11 @@ const confirmDeleteComment = async () => {
     isCommentDeleteModalOpen.value = false;
     commentToDeleteId.value = null;
 
-    showToast('댓글이 성공적으로 삭제되었습니다.', 'success');
+    showToast('응원/질문이 성공적으로 삭제되었습니다.', 'success');
 
   } catch (error) {
     // 삭제 실패 시 모달에 에러 표시
-    const errorMessage = commentStore.error || "댓글 삭제에 실패했습니다. 권한을 확인해 주세요.";
+    const errorMessage = commentStore.error || "응원/질문 삭제에 실패했습니다. 권한을 확인해 주세요.";
     commentDeleteError.value = errorMessage;
     console.error("댓글 삭제 실패:", error);
   }
@@ -273,13 +273,13 @@ const handleLikeConfirm = async () => {
           <div v-if="isAuthor" class="space-x-2">
             <button
                 @click="handleEditPost"
-                class="bg-emerald-500 hover:bg-emerald-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
+                class="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
             >
               수정하기
             </button>
             <button
                 @click="handleDeletePost"
-                class="bg-rose-500 hover:bg-rose-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
+                class="bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
             >
               삭제하기
             </button>
@@ -311,8 +311,8 @@ const handleLikeConfirm = async () => {
     <!-- 2. ⭐️ 댓글 삭제 커스텀 모달 컴포넌트 ⭐️ -->
     <ConfirmationModal
         :show="isCommentDeleteModalOpen"
-        :title="'댓글 삭제 확인'"
-        :message="'정말로 이 댓글을 삭제하시겠습니까? 삭제된 댓글은 복구할 수 없습니다.'"
+        :title="'응원/질문 삭제 확인'"
+        :message="'정말로 이 응원/질문을 삭제하시겠습니까? 삭제된 응원/질문은 복구할 수 없습니다.'"
         :is-loading="commentStore.isLoading"
         :error="commentDeleteError"
         @update:show="isCommentDeleteModalOpen = $event"

--- a/frontend/src/views/BoardDetailView.vue
+++ b/frontend/src/views/BoardDetailView.vue
@@ -305,6 +305,7 @@ const handleLikeConfirm = async () => {
         :is-loading="boardStore.isLoading"
         :error="postDeleteError"
         @update:show="isPostDeleteModalOpen = $event"
+        :confirmButtonText="'삭제하기'"
         @confirm="confirmDeletePost"
     />
 
@@ -316,6 +317,7 @@ const handleLikeConfirm = async () => {
         :is-loading="commentStore.isLoading"
         :error="commentDeleteError"
         @update:show="isCommentDeleteModalOpen = $event"
+        :confirmButtonText="'삭제하기'"
         @confirm="confirmDeleteComment"
     />
 
@@ -332,7 +334,7 @@ const handleLikeConfirm = async () => {
       @update:show="showLikeModal = $event"
       @confirm="handleLikeConfirm"
 
-      title="경고: 로그인 필요"
+      title="로그인 필요"
       message="좋아요를 누르려면 로그인이 필요합니다."
       :is-loading="isProcessing"
       :error="likeError"

--- a/frontend/src/views/BoardDetailView.vue
+++ b/frontend/src/views/BoardDetailView.vue
@@ -213,12 +213,12 @@ const handleLikeConfirm = async () => {
     <div class="container mx-auto p-4 md:p-10 max-w-4xl">
       <div v-if="boardStore.isLoading" class="text-center py-20">
         <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-        <p class="mt-4 text-lg text-gray-600">게시글을 불러오는 중...</p>
+        <p class="mt-4 text-lg text-gray-600">루틴을 불러오는 중...</p>
       </div>
 
       <!-- 게시글을 찾을 수 없는 경우를 postNotFound로 처리 -->
       <div v-else-if="postNotFound" class="text-center py-20 bg-white rounded-xl shadow-lg">
-        <p class="text-2xl text-red-500 font-bold">게시글을 찾을 수 없거나 삭제되었습니다.</p>
+        <p class="text-2xl text-red-500 font-bold">루틴을 찾을 수 없거나 삭제되었습니다.</p>
         <button
             @click="router.push({ name: 'BoardList' })"
             class="mt-6 bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg transition duration-200 shadow"
@@ -273,22 +273,22 @@ const handleLikeConfirm = async () => {
           <div v-if="isAuthor" class="space-x-2">
             <button
                 @click="handleEditPost"
-                class="bg-yellow-500 hover:bg-yellow-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
+                class="bg-emerald-500 hover:bg-emerald-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
             >
-              수정
+              수정하기
             </button>
             <button
                 @click="handleDeletePost"
-                class="bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
+                class="bg-rose-500 hover:bg-rose-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow"
             >
-              삭제
+              삭제하기
             </button>
           </div>
         </footer>
       </div>
 
       <!-- ⭐️ 2. 댓글 섹션 통합 (CommentList 컴포넌트 추가) ⭐️ -->
-      <div class="mt-10">
+      <div class="mt-15">
         <CommentList
             :post-id="postId"
             @open-delete-modal="handleOpenCommentDeleteModal"
@@ -300,8 +300,8 @@ const handleLikeConfirm = async () => {
     <!-- 커스텀 모달 컴포넌트 연결 -->
     <ConfirmationModal
         :show="isPostDeleteModalOpen"
-        :title="'게시글 삭제 확인'"
-        :message="'정말로 이 게시글을 삭제하시겠습니까? 삭제된 게시글은 복구할 수 없습니다.'"
+        :title="'루틴 삭제 확인'"
+        :message="'정말로 이 루틴을 삭제하시겠습니까? 삭제된 루틴은 복구할 수 없습니다.'"
         :is-loading="boardStore.isLoading"
         :error="postDeleteError"
         @update:show="isPostDeleteModalOpen = $event"

--- a/frontend/src/views/BoardDetailView.vue
+++ b/frontend/src/views/BoardDetailView.vue
@@ -300,24 +300,24 @@ const handleLikeConfirm = async () => {
     <!-- 커스텀 모달 컴포넌트 연결 -->
     <ConfirmationModal
         :show="isPostDeleteModalOpen"
-        :title="'루틴 삭제 확인'"
-        :message="'정말로 이 루틴을 삭제하시겠습니까? 삭제된 루틴은 복구할 수 없습니다.'"
+        title="루틴 삭제 확인"
+        message="정말로 이 루틴을 삭제하시겠습니까? 삭제된 루틴은 복구할 수 없습니다."
         :is-loading="boardStore.isLoading"
         :error="postDeleteError"
         @update:show="isPostDeleteModalOpen = $event"
-        :confirmButtonText="'삭제하기'"
+        confirmButtonText="삭제하기"
         @confirm="confirmDeletePost"
     />
 
     <!-- 2. ⭐️ 댓글 삭제 커스텀 모달 컴포넌트 ⭐️ -->
     <ConfirmationModal
         :show="isCommentDeleteModalOpen"
-        :title="'응원/질문 삭제 확인'"
-        :message="'정말로 이 응원/질문을 삭제하시겠습니까? 삭제된 응원/질문은 복구할 수 없습니다.'"
+        title="응원/질문 삭제 확인"
+        message="정말로 이 응원/질문을 삭제하시겠습니까? 삭제된 응원/질문은 복구할 수 없습니다."
         :is-loading="commentStore.isLoading"
         :error="commentDeleteError"
         @update:show="isCommentDeleteModalOpen = $event"
-        :confirmButtonText="'삭제하기'"
+        confirmButtonText="삭제하기"
         @confirm="confirmDeleteComment"
     />
 

--- a/frontend/src/views/BoardDetailView.vue
+++ b/frontend/src/views/BoardDetailView.vue
@@ -28,6 +28,7 @@ const isCommentDeleteModalOpen = ref(false);
 const commentToDeleteId = ref(null); // 삭제할 댓글 ID 저장
 const commentDeleteError = ref(''); // 댓글 삭제 에러 메시지
 
+
 // 1. 좋아요 모달 상태
 const showLikeModal = ref(false);
 // 2. 좋아요 모달 처리 중 로딩 상태 (모달의 isLoading props에 전달)
@@ -39,6 +40,10 @@ const likeError = ref('');
 const isToastVisible = ref(false);
 const toastMessage = ref('');
 const toastType = ref('success');
+
+
+const deleteCommentMessage = "정말로 이 응원/질문을 삭제하시겠습니까?\n삭제된 응원/질문은 복구할 수 없습니다.";
+
 
 // 컴포넌트 마운트 시 상세 정보 로드
 onMounted(async () => { // onMounted 훅을 async로 선언합니다.
@@ -313,7 +318,7 @@ const handleLikeConfirm = async () => {
     <ConfirmationModal
         :show="isCommentDeleteModalOpen"
         title="응원/질문 삭제 확인"
-        message="정말로 이 응원/질문을 삭제하시겠습니까? 삭제된 응원/질문은 복구할 수 없습니다."
+        :message="deleteCommentMessage"
         :is-loading="commentStore.isLoading"
         :error="commentDeleteError"
         @update:show="isCommentDeleteModalOpen = $event"

--- a/frontend/src/views/BoardListView.vue
+++ b/frontend/src/views/BoardListView.vue
@@ -126,20 +126,20 @@ const getSequentialNumber = (index) => {
     <!-- 헤더 및 버튼 -->
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-3xl font-extrabold text-gray-800">
-        게시판 목록 (총 {{ boardStore.postCount }}개)
+        전체 루틴 피드 (총 {{ boardStore.postCount }}개)
       </h1>
       <button
           @click="goToWrite"
-          class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow-md"
+          class="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-2 px-4 rounded-lg transition duration-200 shadow-md"
       >
-        글 작성
+        루틴 기록하기
       </button>
     </div>
 
     <!-- 로딩 상태 -->
     <div v-if="boardStore.isLoading" class="flex justify-center items-center h-48">
-      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
-      <p class="ml-4 text-lg text-gray-600">게시글을 불러오는 중...</p>
+      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-500"></div>
+      <p class="ml-4 text-lg text-gray-600">루틴을 불러오는 중...</p>
     </div>
 
     <!-- 게시글 목록 -->
@@ -149,12 +149,12 @@ const getSequentialNumber = (index) => {
             v-for="(post, index) in boardStore.posts"
             :key="post.id"
             @click="goToDetail(post.id)"
-            class="bg-white p-5 rounded-xl shadow-lg hover:shadow-xl transition duration-300 cursor-pointer border-l-4 border-blue-500 hover:border-blue-700 flex items-center"
+            class="bg-white p-5 rounded-xl shadow-lg hover:shadow-xl transition duration-300 cursor-pointer border-l-4 border-emerald-500 hover:border-emerald-700 flex items-center"
         >
 
           <!-- 1. Left Column: Number (글번호) -->
           <div class="w-16 flex-shrink-0 text-center text-gray-500">
-            <span class="text-lg font-bold text-blue-600">
+            <span class="text-lg font-bold text-emerald-700">
               {{ getSequentialNumber(index) }}
             </span>
           </div>
@@ -174,10 +174,10 @@ const getSequentialNumber = (index) => {
 
           <!-- ⭐️ [수정] 3. Middle Column: Comment Count (댓글 수) - 게시글과 우측 정보 사이 ⭐️ -->
           <div class="hidden sm:flex w-15 flex-shrink-0 flex-col items-center justify-center text-center">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-500 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-cyan-600 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 4v-4z" />
             </svg>
-            <span class="text-md font-semibold" :class="{'text-blue-600': post.commentCount > 0, 'text-gray-400': post.commentCount === 0}">
+            <span class="text-md font-semibold" :class="{'text-gray-600': post.commentCount > 0, 'text-gray-400': post.commentCount === 0}">
                 {{ post.commentCount || 0 }}
             </span>
           </div>
@@ -198,8 +198,8 @@ const getSequentialNumber = (index) => {
       </template>
       <!-- 게시글이 없을 경우 -->
       <div v-else class="text-center py-10 bg-white rounded-xl shadow-lg">
-        <p class="text-xl text-gray-500">아직 작성된 게시글이 없습니다.</p>
-        <p class="text-md text-gray-400 mt-2">새 글을 작성해 보세요!</p>
+        <p class="text-xl text-gray-500">아직 작성된 루틴이 없습니다.</p>
+        <p class="text-md text-gray-400 mt-2">새 루틴을 작성해 보세요!</p>
       </div>
     </div>
     <Pagination

--- a/frontend/src/views/BoardUpdateView.vue
+++ b/frontend/src/views/BoardUpdateView.vue
@@ -92,14 +92,14 @@ const handleSubmit = async () => {
       newContent: postData.value.content
     });
 
-    boardStore.setTransientToast('게시글이 성공적으로 수정되었습니다.', 'success');
+    boardStore.setTransientToast('루틴이 성공적으로 수정되었습니다.', 'success');
 
     // 수정 성공 시 상세 페이지로 이동
     router.push({ name: 'BoardDetail', params: { id: id } });
 
   } catch (error) {
     // API 호출 실패 시 에러 메시지 표시 (백엔드에서 받은 메시지 우선 사용)
-    const message = error.response?.data?.message || '게시글 수정 중 오류가 발생했습니다.';
+    const message = error.response?.data?.message || '루틴 수정 중 오류가 발생했습니다.';
 
     // ⭐️ [수정] 실패: 폼 내부 에러 메시지를 설정하고, 토스트를 'error' 타입으로 즉시 표시 ⭐️
     errorMessage.value = message;
@@ -112,7 +112,7 @@ const handleSubmit = async () => {
 
 <template>
   <div class="container mx-auto p-4 md:p-10 max-w-4xl">
-    <h1 class="text-3xl font-bold mb-6 text-gray-800">게시글 수정</h1>
+    <h1 class="text-3xl font-bold mb-6 text-gray-800">오늘의 루틴 수정</h1>
 
     <!-- 로딩/데이터 없음 인디케이터 -->
     <div v-if="boardStore.isLoading && !postData.id" class="text-center py-20">
@@ -120,7 +120,7 @@ const handleSubmit = async () => {
       <p class="mt-4 text-lg text-blue-600">데이터를 불러오는 중입니다...</p>
     </div>
     <div v-else-if="!boardStore.currentPost && !boardStore.isLoading" class="text-center py-20 bg-white rounded-xl shadow-lg">
-      <p class="text-2xl text-red-500 font-bold">수정할 게시글을 찾을 수 없거나 권한이 없습니다.</p>
+      <p class="text-2xl text-red-500 font-bold">수정할 루틴을 찾을 수 없거나 권한이 없습니다.</p>
       <button
           @click="router.push({ name: 'BoardList' })"
           class="mt-6 bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg transition duration-200 shadow"
@@ -139,7 +139,7 @@ const handleSubmit = async () => {
             v-model="postData.title"
             type="text"
             required
-            placeholder="제목을 입력하세요."
+            placeholder="[카테고리] 루틴을 한 줄로 요약해주세요. (예: [운동] 아침 푸시업 20개 성공)"
             class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition duration-150 text-gray-800"
         />
       </div>
@@ -152,7 +152,7 @@ const handleSubmit = async () => {
             v-model="postData.content"
             required
             rows="10"
-            placeholder="내용을 입력하세요."
+            placeholder="루틴을 실천한 후 느낀 점, 혹은 꾸준히 할 수 있었던 나만의 노하우를 기록해보세요."
             class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition duration-150 text-gray-800 resize-none"
         ></textarea>
       </div>
@@ -169,14 +169,14 @@ const handleSubmit = async () => {
             @click="router.push({ name: 'BoardDetail', params: { id: id } })"
             class="bg-gray-400 hover:bg-gray-500 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-md"
         >
-          취소
+          돌아가기
         </button>
         <button
             type="submit"
             :disabled="!isFormValid || boardStore.isLoading"
             class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          수정 완료
+          수정하기
         </button>
       </div>
     </form>

--- a/frontend/src/views/BoardUpdateView.vue
+++ b/frontend/src/views/BoardUpdateView.vue
@@ -167,14 +167,14 @@ const handleSubmit = async () => {
         <button
             type="button"
             @click="router.push({ name: 'BoardDetail', params: { id: id } })"
-            class="bg-gray-400 hover:bg-gray-500 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-md"
+            class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-3 px-6 rounded-lg transition duration-200 shadow-md"
         >
-          돌아가기
+          취소하기
         </button>
         <button
             type="submit"
             :disabled="!isFormValid || boardStore.isLoading"
-            class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+            class="bg-emerald-500 hover:bg-emerald-600 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
         >
           수정하기
         </button>

--- a/frontend/src/views/BoardWriteView.vue
+++ b/frontend/src/views/BoardWriteView.vue
@@ -50,12 +50,12 @@ const handleSubmit = async () => {
 
 <template>
   <div class="container mx-auto p-4 md:p-10 max-w-4xl">
-    <h1 class="text-3xl font-bold mb-6 text-gray-800">새 게시글 작성</h1>
+    <h1 class="text-3xl font-bold mb-6 text-gray-800">오늘의 루틴 기록</h1>
 
     <!-- 로딩 인디케이터 -->
     <div v-if="boardStore.isLoading" class="text-center py-20">
       <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto"></div>
-      <p class="mt-4 text-lg text-blue-600">게시글을 등록하는 중입니다...</p>
+      <p class="mt-4 text-lg text-blue-600">루틴을 등록하는 중입니다...</p>
     </div>
 
     <!-- 작성 폼 -->
@@ -68,7 +68,7 @@ const handleSubmit = async () => {
             v-model="postData.title"
             type="text"
             required
-            placeholder="제목을 입력하세요."
+            placeholder="[카테고리] 루틴을 한 줄로 요약해주세요. (예: [운동] 아침 푸시업 20개 성공)"
             class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition duration-150 text-gray-800"
         />
       </div>
@@ -81,7 +81,7 @@ const handleSubmit = async () => {
             v-model="postData.content"
             required
             rows="10"
-            placeholder="내용을 입력하세요."
+            placeholder="루틴을 실천한 후 느낀 점, 혹은 꾸준히 할 수 있었던 나만의 노하우를 기록해보세요."
             class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition duration-150 text-gray-800 resize-none"
         ></textarea>
       </div>
@@ -98,14 +98,14 @@ const handleSubmit = async () => {
             @click="router.push({ name: 'BoardList' })"
             class="bg-gray-400 hover:bg-gray-500 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-md"
         >
-          취소
+          돌아가기
         </button>
         <button
             type="submit"
             :disabled="!isFormValid || boardStore.isLoading"
             class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          등록하기
+          기록하기
         </button>
       </div>
     </form>

--- a/frontend/src/views/BoardWriteView.vue
+++ b/frontend/src/views/BoardWriteView.vue
@@ -41,7 +41,7 @@ const handleSubmit = async () => {
     }
   } catch (error) {
     // API 호출 실패 시 에러 메시지 표시 (백엔드에서 받은 메시지 우선 사용)
-    const message = error.response?.data?.message || '게시글 작성 중 오류가 발생했습니다.';
+    const message = error.response?.data?.message || '루틴 작성 중 오류가 발생했습니다.';
     errorMessage.value = message;
     console.error('Submission Error: ', error);
   }
@@ -96,23 +96,18 @@ const handleSubmit = async () => {
         <button
             type="button"
             @click="router.push({ name: 'BoardList' })"
-            class="bg-gray-400 hover:bg-gray-500 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-md"
+            class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-3 px-6 rounded-lg transition duration-200 shadow-md"
         >
-          돌아가기
+          취소하기
         </button>
         <button
             type="submit"
             :disabled="!isFormValid || boardStore.isLoading"
-            class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+            class="bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-3 px-6 rounded-lg transition duration-200 shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
         >
           기록하기
         </button>
       </div>
     </form>
-
-<!--    <div class="mt-8 p-4 border rounded-lg bg-green-50 text-green-700">-->
-<!--      <h2 class="font-bold text-xl">안내</h2>-->
-<!--      <p class="mt-2">이 페이지는 <span class="font-mono bg-green-200 px-1 rounded">requiresAuth: true</span> 메타 태그로 보호되어 있습니다. (src/router/index.js)</p>-->
-<!--    </div>-->
   </div>
 </template>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -96,11 +96,11 @@ const handleWithdrawalConfirm = async () => {
       @update:show="showWithdrawalModal = $event"
       @confirm="handleWithdrawalConfirm"
 
-      title="경고: 회원 탈퇴"
+      title="회원 탈퇴 확인"
       message="정말로 계정을 탈퇴하시겠습니까? 탈퇴 후에는 계정을 복구할 수 없으며, 작성하신 루틴과 응원/질문은 익명 처리됩니다."
       :is-loading="isProcessing"
       :error="withdrawalError"
-      confirm-button-text="탈퇴 확인"
+      confirm-button-text="탈퇴하기"
       confirm-button-class="bg-red-600 hover:bg-red-700"
   />
 </template>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -80,7 +80,7 @@ const handleWithdrawalConfirm = async () => {
       </div>
       <button
           @click="logout"
-          class="mt-6 w-full py-2 px-4 bg-red-500 text-white font-semibold rounded-lg shadow-md hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-opacity-75 transition duration-300"
+          class="mt-6 w-full py-2 px-4 bg-red-500 hover:bg-red-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-opacity-75 transition duration-300"
       >
         로그아웃
       </button>
@@ -97,7 +97,7 @@ const handleWithdrawalConfirm = async () => {
       @confirm="handleWithdrawalConfirm"
 
       title="경고: 회원 탈퇴"
-      message="정말로 계정을 탈퇴하시겠습니까? 탈퇴 후에는 계정을 복구할 수 없으며, 작성하신 게시글과 댓글은 익명 처리됩니다."
+      message="정말로 계정을 탈퇴하시겠습니까? 탈퇴 후에는 계정을 복구할 수 없으며, 작성하신 루틴과 응원/질문은 익명 처리됩니다."
       :is-loading="isProcessing"
       :error="withdrawalError"
       confirm-button-text="탈퇴 확인"


### PR DESCRIPTION
## 🚀 작업 개요 (Summary)
초기 기술 목표(구글 SNS 로그인) 달성 후, 프로덕트의 사용자 경험(UX) 가치를 높이기 위한 컨셉 및 UI/UX 개선을 반영하고, 댓글 작성 기능 및 버그 수정을 완료했습니다.

### 컨셉
**루티노트: 오늘의 작은 성공 기록**
- 성장을 위한 나의 작은 루틴을 기록하고 공유합니다. 
- 요리, 운동, 학습 등 다양한 카테고리의 루틴을 작성할 수 있습니다.
- 사용자와 공유하여 서로 응원하고 격려하며 좋은 습관을 오랫동안 유지할 수 있도록 도웁니다.

## 🛠️ 변경 사항 (Changes)
- [style]: Routinote UI/UX 컨셉 적용 - 전반적인 텍스트/색상 일관성 확보 (버튼 텍스트 4글자, emerald 색상 사용 등)
- [style]: 모달의 배경을 검은배경이 아닌 기존 페이지의 밝기를 낮추도록 변경
- [refactor]: 불필요한 바인딩 제거

## 💡 기술적 회고 및 의사 결정 과정:
### 1. 기술적 목표 우선 달성 후, 비즈니스 목표 강화
초기 프로젝트의 1차 목표는 **구글 SNS 로그인 및 보안 로직 구현**이라는 순수한 **기술적 학습**이었습니다. 해당 목표를 달성한 후, 이 기술 기반 위에 사용자에게 실질적인 가치를 제공하기 위해 **컨셉 및 UI/UX**를 입히는 작업을 진행했습니다.

### 2. 개발 방식의 성찰
개발 초기 단계에서 비즈니스 컨셉을 명확히 설정하지 않은 부분에 대해 회고했습니다. 하지만 이 과정을 통해, **명확한 기술적 목표를 가진 스파이크 솔루션 구현** 이후에 **프로덕트 컨셉을 입혀 완성도를 높이는** 유연한 개발 방식의 장단점을 경험할 수 있었습니다. 향후 프로젝트에서는 초기 기획 단계에서 컨셉을 명확히 설정하여 개발 효율성을 높이도록 노력하겠습니다.

## 📸 스크린샷 또는 테스트 결과 (Optional)
- 기존 일반적인 게시글 작성 페이지에서 루티노트 컨셉 적용
<img width="792" height="547" alt="image" src="https://github.com/user-attachments/assets/ca66647b-e152-49fe-9804-2cf965ea02fd" />

- 버튼 글자 수 통일 및 모달 배경을 흐리게 수정
<img width="798" height="537" alt="image" src="https://github.com/user-attachments/assets/c370c09b-0e0c-432f-9064-70cc5c94648e" />

## 📝 다음 작업 (To-Do / Next Step)
- [feature/docker-setup] 브랜치에서 버전 일치를 위한 도커 적용할 예정입니다.